### PR TITLE
fixed data types in Pierce Scraper

### DIFF
--- a/server/Pierce_Scraper.js
+++ b/server/Pierce_Scraper.js
@@ -2,9 +2,7 @@
 // manually scrape parcel list and add to auction notes
 
 // TODO re-scrape and fix the following
-// tax : add TAXABLE_TOTAL, etc...
-// 		: Fix tax scraper error
-// acres : Change value to number
+// tax : Fix tax scraper error
 
 const webdriver = require('selenium-webdriver');
 const {By, until, Key} = require('selenium-webdriver');
@@ -99,6 +97,20 @@ const getParcelInfo = async function (baseUrl, parcelViewerURL, parcelNum) {
 											
 						// add table data into parcelInfo as key-value pairs
 						currentParcel['Tax'][cellKey] = cellValue;
+
+						// add the needed fields
+						if (cellKey == 'Assessed Total') {
+							// convert cellValue to number and add as 'TAXABLE_TOTAL'
+							currentParcel['Tax']['TAXABLE_TOTAL'] = parseInt(cellValue.replace(',', ''));
+						}
+
+						if (cellKey == 'Assessed Improvements') {
+							currentParcel['Tax']['TAXABLE_BUILDING'] = parseInt(cellValue.replace(',', ''));
+						}
+
+						if (cellKey == 'Assessed Land') {
+							currentParcel['Tax']['TAXABLE_LAND'] = parseInt(cellValue.replace(',', ''));
+						}
 					}
 				}
 			} catch (error) {
@@ -138,6 +150,11 @@ const getParcelInfo = async function (baseUrl, parcelViewerURL, parcelNum) {
 
 						// add table data into parcelInfo as key-value pairs
 						currentParcel['Land'][cellKey] = cellValue;
+
+						// store 'Acres' as a float not a string
+						if (cellKey == 'Acres') {
+							currentParcel['Land']['Acres'] = parseFloat(cellValue.replace(',',''));
+						}
 					}
 				}
 			} catch (error) {

--- a/server/Scraper.test.js
+++ b/server/Scraper.test.js
@@ -90,7 +90,7 @@ test('Pierce County Scraper', async () => {
 	expect(fetchedAddress).toEqual('7019 180TH AVE SW');
 	expect(fetchedYear).toEqual('1981');
 	expect(fetchedTaxValue).toEqual('44,920');
-	expect(fetchedAcres).toEqual('5.09');
+	expect(fetchedAcres).toEqual(5.09);
 	expect(fetchedSquareFeet).toEqual('1,440');
 	expect(fetchedLat).toEqual('47.193147');
 	//expect(fetchedSaleDate).toEqual('10/01/1999');


### PR DESCRIPTION
Front end expects all parcel objects to have certain fields and data types. Pierce scraper was missing 'TAXABLE_TOTAL', 'TAXABLE_LAND', and 'TAXABLE_BUILDING'. parcel object field ['Building']['Acres'] was converted form a string to a float. Re-scraped Pierce County with the above changes.